### PR TITLE
account_ebics - prevent cryptography into newest versions

### DIFF
--- a/account_ebics/__manifest__.py
+++ b/account_ebics/__manifest__.py
@@ -21,13 +21,13 @@
         'wizards/ebics_xfer.xml',
         'views/menu.xml',
     ],
-    'installable': True,
-    'application': True,
-    'external_dependencies': {
-        'python': [
-            'fintech',
-            'cryptography',
-            ]
-        },
+    "installable": True,
+    "application": True,
+    "external_dependencies": {
+        "python": [
+            "fintech",
+            "cryptography<=39.0.2",
+        ]
+    },
     "images": ["static/description/cover.png"],
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# generated from manifests external_dependencies
+cryptography<=39.0.2
+fintech


### PR DESCRIPTION
Check Cryptography 41.0 which drops the support for Python 3.6