### PR TITLE
EBICS User ID - correct handling of user_ids and UI designation

### DIFF
--- a/account_ebics/README.rst
+++ b/account_ebics/README.rst
@@ -167,7 +167,7 @@ Most commonly used formats for which support is available in Odoo should be ther
 
 Please open an issue on https://github.com/Noviat/account_ebics to report missing EBICS File Formats.
 
-For File Formats of type 'Downloads' you can also specifiy a 'Download Process Method'.
+For File Formats of type 'Downloads' you can also specify a 'Download Process Method'.
 
 This is the method that will be executed when hitting the 'Process' button on the downloaded file.
 
@@ -205,7 +205,7 @@ During the processing of your EBICS upload/download, your bank may return an Err
 EBICS Functional Error:
 EBICS_NO_DOWNLOAD_DATA_AVAILABLE (code: 90005)
 
-A detailled explanation of the codes can be found on http://www.ebics.org.
+A detailed explanation of the codes can be found on http://www.ebics.org.
 You can also find this information in the doc folder of this module (file EBICS_Annex1_ReturnCodes).
 
 |
@@ -213,7 +213,7 @@ You can also find this information in the doc folder of this module (file EBICS_
 Known Issues / Roadmap
 ======================
 
-- add support to import externally generated keys & certificates (currently only 3SKey signature certificate).
+- Add support to import externally generated keys & certificates (currently only 3SKey signature certificate).
 - For Odoo 16.0 the interaction with the OCA payment order and bank statement import modules (e.g. french CFONB) is not yet available.
 - Electronic Distributed Signature (EDS) is not supported in the current version of this module.
 

--- a/account_ebics/__manifest__.py
+++ b/account_ebics/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "EBICS banking protocol",
-    "version": "16.0.1.2.0",
+    "version": "16.0.1.3.0",
     "license": "LGPL-3",
     "author": "Noviat",
     "website": "https://www.noviat.com",

--- a/account_ebics/models/ebics_userid.py
+++ b/account_ebics/models/ebics_userid.py
@@ -84,6 +84,17 @@ class EbicsUserID(models.Model):
         "This default can be overriden for specific "
         "EBICS transactions (cf. File Formats).",
     )
+    ui_designation = fields.Selection(
+        [
+            ("both", "Download and Upload"),
+            ("down", "Download Only"),
+            ("up", "Upload Only"),
+        ],
+        string="UI Designation",
+        default="both",
+        required=True,
+        help="Defines in what form this User will be available for selection.",
+    )
     ebics_keys_fn = fields.Char(compute="_compute_ebics_keys_fn")
     ebics_keys_found = fields.Boolean(compute="_compute_ebics_keys_found")
     ebics_passphrase = fields.Char(string="EBICS Passphrase")

--- a/account_ebics/views/ebics_userid_views.xml
+++ b/account_ebics/views/ebics_userid_views.xml
@@ -95,6 +95,7 @@
                         />
             <field name="ebics_passphrase_store" />
             <field name="active" />
+            <field name="ui_designation" />
           </group>
           <group name="main-right">
             <field name="signature_class" />

--- a/account_ebics/wizards/ebics_xfer.py
+++ b/account_ebics/wizards/ebics_xfer.py
@@ -113,29 +113,40 @@ class EbicsXfer(models.TransientModel):
 
     @api.onchange("ebics_config_id")
     def _onchange_ebics_config_id(self):
-        ebics_userids = self.ebics_config_id.ebics_userid_ids
-        if self.env.context.get("ebics_download"):
-            download_formats = self.ebics_config_id.ebics_file_format_ids.filtered(
+        avail_userids = self.ebics_config_id.ebics_userid_ids.filtered(
+            lambda r: self.env.user.id in r.user_ids.ids
+        )
+
+        if self.env.context.get("ebics_download"):  # Download Form
+            avail_formats = self.ebics_config_id.ebics_file_format_ids.filtered(
                 lambda r: r.type == "down"
             )
-            if len(download_formats) == 1:
-                self.format_id = download_formats
-            if len(ebics_userids) == 1:
-                self.ebics_userid_id = ebics_userids
-            else:
-                transport_users = ebics_userids.filtered(
-                    lambda r: r.signature_class == "T"
-                )
-                if len(transport_users) == 1:
-                    self.ebics_userid_id = transport_users
-        else:
-            upload_formats = self.ebics_config_id.ebics_file_format_ids.filtered(
+            avail_userids = avail_userids.filtered(
+                lambda r: r.ui_designation in ["both", 'down']
+            )
+        else:  # Upload Form
+            avail_formats = self.ebics_config_id.ebics_file_format_ids.filtered(
                 lambda r: r.type == "up"
             )
-            if len(upload_formats) == 1:
-                self.format_id = upload_formats
-            if len(ebics_userids) == 1:
-                self.ebics_userid_id = ebics_userids
+            avail_userids = avail_userids.filtered(
+                lambda r: r.ui_designation in ["both", "up"]
+            )
+
+        if avail_formats and len(avail_formats) == 1:
+            self.format_id = avail_formats
+        else:
+            self.format_id = False
+        if avail_userids:
+            if len(avail_userids) == 1:
+                self.ebics_userid_id = avail_userids
+            else:
+                with_passphrs_userids = avail_userids.filtered(
+                    lambda r: r.ebics_passphrase_store
+                )
+                if len(with_passphrs_userids) == 1:
+                    self.ebics_userid_id = with_passphrs_userids
+        else:
+            self.ebics_userid_id = False
 
     @api.onchange("upload_data")
     def _onchange_upload_data(self):

--- a/account_ebics/wizards/ebics_xfer.xml
+++ b/account_ebics/wizards/ebics_xfer.xml
@@ -16,7 +16,7 @@
                     />
           <field
                         name="ebics_userid_id"
-                        domain="[('ebics_config_id', '=', ebics_config_id)]"
+                        domain="[('ebics_config_id', '=', ebics_config_id), ('user_ids.id', '=', uid), ('ui_designation', 'in', ['both', 'down'])]"
                         required="1"
                         options="{'no_create': True, 'no_open': True}"
                     />
@@ -69,7 +69,7 @@
                     />
           <field
                         name="ebics_userid_id"
-                        domain="[('ebics_config_id', '=', ebics_config_id)]"
+                        domain="[('ebics_config_id', '=', ebics_config_id), ('user_ids.id', '=', uid), ('ui_designation', 'in', ['both', 'up'])]"
                         required="1"
                         options="{'no_create': True, 'no_open': True}"
                     />
@@ -143,7 +143,7 @@
   </record>
 
   <record id="ebics_xfer_action_download" model="ir.actions.act_window">
-    <field name="name">EBICS File Transfer</field>
+    <field name="name">EBICS File Transfer - Download</field>
     <field name="type">ir.actions.act_window</field>
     <field name="res_model">ebics.xfer</field>
     <field name="view_mode">form</field>
@@ -153,7 +153,7 @@
   </record>
 
   <record id="ebics_xfer_action_upload" model="ir.actions.act_window">
-    <field name="name">EBICS File Transfer</field>
+    <field name="name">EBICS File Transfer - Upload</field>
     <field name="type">ir.actions.act_window</field>
     <field name="res_model">ebics.xfer</field>
     <field name="view_mode">form</field>


### PR DESCRIPTION
Updates:
- EbicsUserID.user_ids now correctly used for filters in the Upload/Download forms.
- New "UI designation" option for the EbicsUserID - allows to assign certain keys to EBICS Upload/Download forms for better usability.
- Prioritization (not filtering) in the UI of keys with a stored passphrase (if they are valid for current user).
- Minor fix of typos.