### PR TITLE
[16.0][FIX] handle string notifications as warnings

### DIFF
--- a/account_ebics/models/ebics_file.py
+++ b/account_ebics/models/ebics_file.py
@@ -253,14 +253,17 @@ class EbicsFile(models.Model):
             errors = []
             warnings = []
             for notif in notifications:
-                if notif["type"] == "error":
+                if isinstance(notif, dict) and notif["type"] == "error":
                     error_cnt += 1
                     parts = [notif[k] for k in notif if k in ("message", "details")]
                     errors.append("\n".join(parts))
-                elif notif["type"] == "warning":
+                elif isinstance(notif, dict) and notif["type"] == "warning":
                     warning_cnt += 1
                     parts = [notif[k] for k in notif if k in ("message", "details")]
                     warnings.append("\n".join(parts))
+                elif isinstance(notif, str):
+                    warning_cnt += 1
+                    warnings.append(notif + "\n")
 
         self.note_process += _("Process file %(fn)s results:", fn=self.name)
         if error_cnt:


### PR DESCRIPTION
When using EBICS import, if you already had the transaction lines in another account.bank.statement, during import, you may get string appended to res["notifications"], as per https://github.com/OCA/bank-statement-import/blob/f50c272fde2b361e53506918d0a9f914e4f9eba9/account_statement_import_file/wizard/account_statement_import.py#L349-L357

In this case, the creation of bank statement will fail since account_ebics expects res["notifications"] to contain only dictionaries, like 
```python
{
    "type": "error",
    "message": "error message"
}
```
and import will fail on this line : https://github.com/Noviat/account_ebics/blob/ccad5d6b2dbddf69d2ea68fa1aabb95244ceb32c/account_ebics/models/ebics_file.py#L256

This PR fixes this by checking whether each notification is a dict, if it is a string, it is added directly as a warning.