### PR TITLE
fix cfonb return line bug (for branch v17)

### DIFF
--- a/account_ebics/models/ebics_file.py
+++ b/account_ebics/models/ebics_file.py
@@ -369,8 +369,7 @@ class EbicsFile(models.Model):
         Statements without transactions are removed.
         """
         datas = []
-        file_data = base64.b64decode(self.data)
-        file_data.replace(b"\n", b"").replace(b"\r", b"")
+        file_data = base64.b64decode(self.data).replace(b"\n", b"").replace(b"\r", b"")
         if len(file_data) % 120:
             message = _(
                 "Incorrect CFONB120 file:\n"


### PR DESCRIPTION
A small typo in _split_cfonb() function ignores line return removal, leading to error "the file is not divisible in 120 char lines".

This pull request fix it.