### PR TITLE
[IMP] account_ebics - refactor ebics file form & list views

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Available addons
 ----------------
 addon | version | maintainers | summary
 --- | --- | --- | ---
-[account_ebics](account_ebics/) | 18.0.1.0.3 |  | EBICS banking protocol
+[account_ebics](account_ebics/) | 18.0.1.1.0 |  | EBICS banking protocol
 [account_ebics_batch](account_ebics_batch/) | 18.0.1.0.0 |  | EBICS Files automated import and processing
 [account_ebics_batch_payment](account_ebics_batch_payment/) | 18.0.1.0.0 |  | Upload Batch Payment via EBICS
 [account_ebics_oca_statement_import](account_ebics_oca_statement_import/) | 18.0.1.0.0 |  | Use OCA Bank Statement Import with account_ebics

--- a/account_ebics/__manifest__.py
+++ b/account_ebics/__manifest__.py
@@ -1,9 +1,9 @@
-# Copyright 2009-2025 Noviat.
+# Copyright 2015 Noviat.
 # License LGPL-3 or later (https://www.gnu.org/licenses/lgpl).
 
 {
     "name": "EBICS banking protocol",
-    "version": "18.0.1.0.3",
+    "version": "18.0.1.1.0",
     "license": "LGPL-3",
     "author": "Noviat",
     "website": "https://www.noviat.com/",

--- a/account_ebics/views/ebics_file_views.xml
+++ b/account_ebics/views/ebics_file_views.xml
@@ -4,7 +4,7 @@
         <field name="name">ebics.file.search</field>
         <field name="model">ebics.file</field>
         <field name="arch" type="xml">
-            <search string="Search EBICS Files">
+            <search>
                 <field name="date_from" />
                 <field name="date_to" />
                 <field name="name" />
@@ -42,17 +42,30 @@
         </field>
     </record>
 
-    <!-- Download -->
-
-    <record id="ebics_file_view_list_download" model="ir.ui.view">
+    <record id="ebics_file_view_list" model="ir.ui.view">
         <field name="name">ebics.file.list</field>
         <field name="model">ebics.file</field>
         <field name="arch" type="xml">
             <list decoration-muted="state=='draft'" create="false">
-                <field name="date" string="Download Date" />
+                <field
+                    name="date"
+                    string="Download Date"
+                    column_invisible="context.get('ebics_mode') != 'down'"
+                />
+                <field
+                    name="date"
+                    string="Upload Date"
+                    column_invisible="context.get('ebics_mode') == 'down'"
+                />
                 <field name="name" />
-                <field name="date_from" />
-                <field name="date_to" />
+                <field
+                    name="date_from"
+                    column_invisible="context.get('ebics_mode') != 'down'"
+                />
+                <field
+                    name="date_to"
+                    column_invisible="context.get('ebics_mode') != 'down'"
+                />
                 <field name="user_id" />
                 <field name="state" />
                 <field name="format_id" />
@@ -65,72 +78,94 @@
         </field>
     </record>
 
-    <record id="ebics_file_view_form_download" model="ir.ui.view">
+    <record id="ebics_file_view_form" model="ir.ui.view">
         <field name="name">ebics.file.form</field>
         <field name="model">ebics.file</field>
         <field name="priority">1</field>
         <field name="arch" type="xml">
-            <form string="EBICS File" create="false">
+            <form create="false">
                 <header>
-                    <field name="download_process_method" invisible="1" />
                     <button
                         name="set_to_draft"
-                        invisible="not download_process_method or state != 'done'"
                         string="Set to Draft"
                         type="object"
                         groups="account.group_account_manager"
+                        invisible="(context.get('ebics_mode') == 'down' and (not download_process_method or state != 'done')) or (context.get('ebics_mode') == 'up' and state != 'done')"
                     />
+
                     <button
                         name="process"
                         class="oe_highlight"
-                        invisible="not download_process_method or state != 'draft'"
                         string="Process"
                         type="object"
                         groups="account.group_account_invoice"
                         help="Process the EBICS File"
+                        invisible="(context.get('ebics_mode') == 'down' and (not download_process_method or state != 'draft')) or (context.get('ebics_mode') == 'up')"
                     />
+
                     <button
                         name="set_to_done"
-                        invisible="not download_process_method or state != 'draft'"
                         string="Set to Done"
                         type="object"
                         groups="account.group_account_manager"
+                        invisible="(context.get('ebics_mode') == 'down' and (not download_process_method or state != 'draft')) or (context.get('ebics_mode') == 'up' and state != 'draft')"
                     />
+
                     <field
                         name="state"
                         widget="statusbar"
-                        invisible="not download_process_method"
+                        invisible="context.get('ebics_mode') == 'down' and not download_process_method"
                     />
                 </header>
-                <group name="main">
-                    <group name="main-full-screen" colspan="2" col="2">
-                        <field name="name" />
-                        <field name="data" filename="name" />
-                        <field name="format_id" />
+                <sheet>
+                    <group name="main">
+                        <group name="main-full-screen" colspan="2" col="2">
+                            <field name="name" />
+                            <field name="data" filename="name" />
+                            <field name="format_id" />
+                        </group>
+                        <group name="main-left">
+                            <field
+                                name="date"
+                                string="Download Date"
+                                invisible="context.get('ebics_mode') != 'down'"
+                            />
+                            <field
+                                name="date"
+                                string="Upload Date"
+                                invisible="context.get('ebics_mode') == 'down'"
+                            />
+                            <field name="user_id" />
+                            <field name="ebics_userid_id" />
+                        </group>
+                        <group name="main-right">
+                            <field
+                                name="date_from"
+                                invisible="context.get('ebics_mode') != 'down'"
+                            />
+                            <field
+                                name="date_to"
+                                invisible="context.get('ebics_mode') != 'down'"
+                            />
+                            <field
+                                name="company_ids"
+                                widget="many2many_tags"
+                                groups="base.group_multi_company"
+                            />
+                        </group>
                     </group>
-                    <group name="main-left">
-                        <field name="date" string="Download Date" />
-                        <field name="user_id" />
-                        <field name="ebics_userid_id" />
-                    </group>
-                    <group name="main-right">
-                        <field name="date_from" />
-                        <field name="date_to" />
-                        <field
-                            name="company_ids"
-                            widget="many2many_tags"
-                            groups="base.group_multi_company"
-                        />
-                    </group>
-                </group>
-                <notebook>
-                    <page string="Additional Information">
-                        <field name="note" nolabel="1" />
-                    </page>
-                    <page string="Bank Statements" invisible="not bank_statement_ids">
-                        <field name="bank_statement_ids" nolabel="1" />
-                    </page>
-                </notebook>
+                    <notebook>
+                        <page string="Additional Information">
+                            <field name="note" nolabel="1" />
+                        </page>
+                        <page
+                            string="Bank Statements"
+                            invisible="not bank_statement_ids"
+                        >
+                            <field name="bank_statement_ids" nolabel="1" />
+                        </page>
+                    </notebook>
+                </sheet>
             </form>
         </field>
     </record>
@@ -138,7 +173,7 @@
     <record id="ebics_file_view_form_result" model="ir.ui.view">
         <field name="name">ebics.file.process.result</field>
         <field name="model">ebics.file</field>
-        <field name="priority">2</field>
+        <field name="priority">100</field>
         <field name="arch" type="xml">
             <form string="Process EBICS File">
                 <separator colspan="4" string="Results :" />
@@ -168,89 +203,8 @@
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">ebics.file</field>
         <field name="view_mode">list,form</field>
-        <field name="view_id" eval="False" />
         <field name="domain">[('type', '=', 'down')]</field>
-        <field name="search_view_id" ref="ebics_file_view_search" />
-    </record>
-
-    <record id="ebics_file_action_download_list" model="ir.actions.act_window.view">
-        <field eval="1" name="sequence" />
-        <field name="view_mode">list</field>
-        <field name="view_id" ref="ebics_file_view_list_download" />
-        <field name="act_window_id" ref="ebics_file_action_download" />
-    </record>
-
-    <record id="ebics_file_action_download_form" model="ir.actions.act_window.view">
-        <field eval="2" name="sequence" />
-        <field name="view_mode">form</field>
-        <field name="view_id" ref="ebics_file_view_form_download" />
-        <field name="act_window_id" ref="ebics_file_action_download" />
-    </record>
-
-    <!-- Upload -->
-
-    <record id="ebics_file_view_list_upload" model="ir.ui.view">
-        <field name="name">ebics.file.list</field>
-        <field name="model">ebics.file</field>
-        <field name="arch" type="xml">
-            <list decoration-muted="state=='draft'" create="false">
-                <field name="date" string="Upload Date" />
-                <field name="name" />
-                <field name="user_id" />
-                <field name="state" />
-                <field name="format_id" />
-                <field
-                    name="company_ids"
-                    widget="many2many_tags"
-                    groups="base.group_multi_company"
-                />
-            </list>
-        </field>
-    </record>
-
-    <record id="ebics_file_view_form_upload" model="ir.ui.view">
-        <field name="name">ebics.file.form</field>
-        <field name="model">ebics.file</field>
-        <field name="priority">1</field>
-        <field name="arch" type="xml">
-            <form string="EBICS File" create="false">
-                <header>
-                    <button
-                        name="set_to_draft"
-                        invisible="state != 'done'"
-                        string="Set to Draft"
-                        type="object"
-                        groups="account.group_account_manager"
-                    />
-                    <button
-                        name="set_to_done"
-                        invisible="state != 'draft'"
-                        string="Set to Done"
-                        type="object"
-                        groups="account.group_account_manager"
-                    />
-                    <field name="state" widget="statusbar" />
-                </header>
-                <group colspan="4" col="4">
-                    <field name="date" string="Upload Date" />
-                    <field name="name" />
-                    <field name="data" filename="name" />
-                    <field name="format_id" />
-                    <field name="user_id" />
-                    <field name="ebics_userid_id" />
-                    <field
-                        name="company_ids"
-                        widget="many2many_tags"
-                        groups="base.group_multi_company"
-                    />
-                </group>
-                <notebook>
-                    <page string="Additional Information">
-                        <field name="note" nolabel="1" />
-                    </page>
-                </notebook>
-            </form>
-        </field>
+        <field name="context">{'ebics_mode': 'down'}</field>
     </record>
 
     <record id="ebics_file_action_upload" model="ir.actions.act_window">
@@ -258,22 +212,7 @@
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">ebics.file</field>
         <field name="view_mode">list,form</field>
-        <field name="view_id" eval="False" />
         <field name="domain">[('type', '=', 'up')]</field>
-        <field name="search_view_id" ref="ebics_file_view_search" />
-    </record>
-
-    <record id="ebics_file_action_upload_list" model="ir.actions.act_window.view">
-        <field eval="1" name="sequence" />
-        <field name="view_mode">list</field>
-        <field name="view_id" ref="ebics_file_view_list_upload" />
-        <field name="act_window_id" ref="ebics_file_action_upload" />
-    </record>
-
-    <record id="ebics_file_action_upload_form" model="ir.actions.act_window.view">
-        <field eval="2" name="sequence" />
-        <field name="view_mode">form</field>
-        <field name="view_id" ref="ebics_file_view_form_upload" />
-        <field name="act_window_id" ref="ebics_file_action_upload" />
+        <field name="context">{'ebics_mode': 'up'}</field>
     </record>
 </odoo>


### PR DESCRIPTION
This PR removes the use of ir.actions.act_window.view records, as these can lead to issues during migrations.
In this case, the migration to 18.0 produced the following error :

```
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "act_window_view_unique_mode_per_action"
DETAIL:  Key (act_window_id, view_mode)=(2325, list) already exists.

<record id="ebics_file_action_download_list" model="ir.actions.act_window.view">
        <field eval="1" name="sequence"/>
        <field name="view_mode">list</field>
        <field name="view_id" ref="ebics_file_view_list_download"/>
        <field name="act_window_id" ref="ebics_file_action_download"/>
</record>
```

The issue comes from the fact that this ir.actions.act_window.view entry was altered during the migration :

<img width="770" height="247" alt="image" src="https://github.com/user-attachments/assets/55e126ec-e0e3-4ee2-a4e2-88acb3a62565" />

To avoid this type of conflict entirely, the PR removes these ir.actions.act_window.view records and simplifies the list and form views.