### PR TITLE
FIX account_ebics_oca_statement_import type error

### DIFF
--- a/account_ebics_oca_statement_import/wizards/account_statement_import.py
+++ b/account_ebics_oca_statement_import/wizards/account_statement_import.py
@@ -17,26 +17,29 @@ class AccountStatementImport(models.TransientModel):
     def _match_journal(self, account_number, currency):
         journal = self.env["account.journal"]
         sanitized_account_number = self._sanitize_account_number(account_number)
-        fin_journals = self.env["account.journal"].search(
-            [
-                ("type", "=", "bank"),
-                "|",
-                ("currency_id", "=", currency.id),
-                ("company_id.currency_id", "=", currency.id),
-            ]
-        )
-        fin_journal = fin_journals.filtered(
-            lambda r: sanitized_account_number
-            in (r.bank_account_id.sanitized_acc_number or "")
-        )
-        if len(fin_journal) == 1:
-            journal = fin_journal
+        if sanitized_account_number:
+            fin_journals = self.env["account.journal"].search(
+                [
+                    ("type", "=", "bank"),
+                    "|",
+                    ("currency_id", "=", currency.id),
+                    ("company_id.currency_id", "=", currency.id),
+                ]
+            )
+            fin_journal = fin_journals.filtered(
+                lambda r: sanitized_account_number
+                in (r.bank_account_id.sanitized_acc_number or "")
+            )
+            if len(fin_journal) == 1:
+                journal = fin_journal
         if not journal:
             journal = super()._match_journal(account_number, currency)
         return journal
 
     def _sanitize_account_number(self, account_number):
         sanitized_number = sanitize_account_number(account_number)
+        if not sanitized_number:
+            return sanitized_number
         check_curr = sanitized_number[-3:]
         if check_curr.isalpha():
             all_currencies = self.env["res.currency"].search([])


### PR DESCRIPTION
This fixes the following error which occurs when importing bank statements without bank account number.

```
Odoo Server Error

Occured on shop.nitrokey.com on model account.statement.import on 2026-05-12 11:44:00 GMT

Traceback (most recent call last):
File "/srv/odoo/odoo/parts/odoo/odoo/http.py", line 2167, in _transactioning
return service_model.retrying(func, env=self.env)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/srv/odoo/odoo/parts/odoo/odoo/service/model.py", line 157, in retrying
result = func()
^^^^^^
File "/srv/odoo/odoo/parts/odoo/odoo/http.py", line 2134, in _serve_ir_http
response = self.dispatcher.dispatch(rule.endpoint, args)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/srv/odoo/odoo/parts/odoo/odoo/http.py", line 2382, in dispatch
result = self.request.registry['ir.http']._dispatch(endpoint)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/srv/odoo/odoo/parts/odoo/odoo/addons/base/models/ir_http.py", line 333, in _dispatch
result = endpoint(**request.params)
^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/srv/odoo/odoo/parts/odoo/odoo/http.py", line 754, in route_wrapper
result = endpoint(self, *args, **params_ok)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/tmp/addons/web/controllers/dataset.py", line 42, in call_button
action = call_kw(request.env[model], method, args, kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/srv/odoo/odoo/parts/odoo/odoo/api.py", line 535, in call_kw
result = getattr(recs, name)(*args, **kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/tmp/addons/account_statement_import_file/wizard/account_statement_import.py", line 53, in import_file_button
result = self._import_file()
^^^^^^^^^^^^^^^^^^^
File "/tmp/addons/account_statement_import_file/wizard/account_statement_import.py", line 33, in _import_file
self.import_single_file(file_data, result)
File "/tmp/addons/account_statement_import_file/wizard/account_statement_import.py", line 99, in import_single_file
self.import_single_statement(single_statement_data, result)
File "/tmp/addons/account_statement_import_file/wizard/account_statement_import.py", line 118, in import_single_statement
journal = self._match_journal(account_number, currency)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/tmp/addons/account_ebics_oca_statement_import/wizards/account_statement_import.py", line 19, in _match_journal
sanitized_account_number = self._sanitize_account_number(account_number)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/tmp/addons/account_ebics_oca_statement_import/wizards/account_statement_import.py", line 40, in _sanitize_account_number
check_curr = sanitized_number[-3:]
~~~~~~~~~~~~~~~~^^^^^
TypeError: 'bool' object is not subscriptable

The above server error caused the following client error:
RPC_ERROR: Odoo Server Error
RPCError@https://shop.nitrokey.com/web/assets/4bb4d25/web.assets_web.min.js:3174:338
makeErrorFromResponse@https://shop.nitrokey.com/web/assets/4bb4d25/web.assets_web.min.js:3178:165
rpc._rpc/promise</<@https://shop.nitrokey.com/web/assets/4bb4d25/web.assets_web.min.js:3184:34
```